### PR TITLE
[gitignore] Remove webpack.config from ignored files

### DIFF
--- a/demo/src/main/ts/.gitignore
+++ b/demo/src/main/ts/.gitignore
@@ -1,2 +1,3 @@
 *.js.map
 *.js
+!webpack.config.js


### PR DESCRIPTION
`webpack.config.js` in `demo` is ignored, as part of `*.js` rule in gitignore.
I'm not sure how I got it by cloning this repo, but changing git origin later this file was lost.

Anyway it should not be ignored.