### PR TITLE
feat: null types for ts generation

### DIFF
--- a/aem-react-api/src/main/java/com/sinnerschrader/aem/reactapi/typescript/NotNull.java
+++ b/aem-react-api/src/main/java/com/sinnerschrader/aem/reactapi/typescript/NotNull.java
@@ -1,0 +1,14 @@
+package com.sinnerschrader.aem.reactapi.typescript;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+public @interface NotNull {
+
+}

--- a/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/descriptor/PropertyDescriptor.java
+++ b/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/descriptor/PropertyDescriptor.java
@@ -10,4 +10,6 @@ public class PropertyDescriptor {
 
 	private String name;
 
+	private boolean isNotNullable;
+
 }

--- a/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/descriptor/TypeDescriptor.java
+++ b/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/descriptor/TypeDescriptor.java
@@ -23,6 +23,8 @@ public class TypeDescriptor
 
 	public static final String MAP = "{}";
 
+	public static final String NULL = "null";
+
 	private String type;
 
 	private boolean map;

--- a/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/fromclass/GeneratorFromClass.java
+++ b/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/fromclass/GeneratorFromClass.java
@@ -1,31 +1,21 @@
 package com.sinnerschrader.aem.react.tsgenerator.fromclass;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sinnerschrader.aem.react.tsgenerator.descriptor.*;
+import com.sinnerschrader.aem.react.tsgenerator.descriptor.ClassDescriptor.ClassDescriptorBuilder;
+import com.sinnerschrader.aem.react.tsgenerator.generator.PathMapper;
+import com.sinnerschrader.aem.reactapi.typescript.Element;
+import com.sinnerschrader.aem.reactapi.typescript.NotNull;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.EnumUtils;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang.ClassUtils;
-import org.apache.commons.lang3.EnumUtils;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.ClassDescriptor;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.ClassDescriptor.ClassDescriptorBuilder;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.Discriminator;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.EnumDescriptor;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.ScanContext;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.TypeDescriptor;
-import com.sinnerschrader.aem.react.tsgenerator.descriptor.UnionType;
-import com.sinnerschrader.aem.react.tsgenerator.generator.PathMapper;
-import com.sinnerschrader.aem.reactapi.typescript.Element;
 
 public class GeneratorFromClass {
 	public static final Set<String> BLACKLIST = Collections.unmodifiableSet(new HashSet<String>() {
@@ -131,6 +121,7 @@ public class GeneratorFromClass {
 								.builder()//
 								.name(pd.getName())//
 								.type(convertType(pd.getPropertyType(), element, mapper))//
+								.isNotNullable(isNotNull(pd))
 								.build();
 
 						cd.getProperties().put(pdd.getName(), pdd);
@@ -161,6 +152,13 @@ public class GeneratorFromClass {
 				.fullJavaClassName(enumClass.getName())//
 				.values(map.values().stream().map((E e) -> e.name()).sorted().collect(Collectors.toList()))//
 				.build();
+	}
+
+	private static boolean isNotNull(PropertyDescriptor pd) {
+		return Optional.ofNullable(pd.getReadMethod())
+				.map(it -> it.getAnnotation(NotNull.class) != null
+						|| it.getReturnType().equals(boolean.class))
+				.orElse(false);
 	}
 
 }

--- a/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/generator/TypeScriptGenerator.java
+++ b/generate-typescript-maven-plugin/src/main/java/com/sinnerschrader/aem/react/tsgenerator/generator/TypeScriptGenerator.java
@@ -2,10 +2,13 @@ package com.sinnerschrader.aem.react.tsgenerator.generator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.google.inject.internal.util.ImmutableList;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.logging.Log;
 
@@ -69,12 +72,9 @@ public class TypeScriptGenerator {
 						.build());
 			}
 
-			final String fullType = prop.getType().isArray() ? prop.getType().getType() + "[]"
-					: prop.getType().isMap() ? "{[key: string]: " + prop.getType().getType() + "}"
-							: prop.getType().getType();
 			fields.add(FieldModel.builder()//
 					.name(prop.getName())//
-					.types(new String[] { fullType })//
+					.types(getTypes(prop))//
 					.build());
 		}
 
@@ -143,6 +143,19 @@ public class TypeScriptGenerator {
 		String content = FileUtils.readFileToString(file);
 		return new StringTemplateSource(file.getAbsolutePath(), content);
 
+	}
+
+	private String[] getTypes(PropertyDescriptor prop) {
+		final String fullType = prop.getType().isArray() ? prop.getType().getType() + "[]"
+				: prop.getType().isMap() ? "{[key: string]: " + prop.getType().getType() + "}"
+				: prop.getType().getType();
+
+		ImmutableList.Builder<String> builder = ImmutableList.builder();
+		builder.add(fullType);
+		if(!prop.isNotNullable()) {
+			builder.add(TypeDescriptor.NULL);
+		}
+		return builder.build().toArray(new String[]{});
 	}
 
 }

--- a/generate-typescript-maven-plugin/src/test/java/com/sinnerschrader/aem/react/tsgenerator/generator/TestNotNull.java
+++ b/generate-typescript-maven-plugin/src/test/java/com/sinnerschrader/aem/react/tsgenerator/generator/TestNotNull.java
@@ -1,0 +1,20 @@
+package com.sinnerschrader.aem.react.tsgenerator.generator;
+
+import com.sinnerschrader.aem.reactapi.typescript.NotNull;
+
+public class TestNotNull {
+
+    private String value;
+
+    @NotNull
+    public String getValue() {
+        return value;
+    }
+
+    private boolean done;
+
+    public boolean isDone() {
+        return done;
+    }
+
+}

--- a/generate-typescript-maven-plugin/src/test/java/com/sinnerschrader/aem/react/tsgenerator/generator/TypeScriptGeneratorTest.java
+++ b/generate-typescript-maven-plugin/src/test/java/com/sinnerschrader/aem/react/tsgenerator/generator/TypeScriptGeneratorTest.java
@@ -2,6 +2,7 @@ package com.sinnerschrader.aem.react.tsgenerator.generator;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Iterator;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,7 +28,11 @@ public class TypeScriptGeneratorTest {
 		Assert.assertEquals(1, generate.getFields().size());
 		FieldModel field = generate.getFields().iterator().next();
 		Assert.assertEquals("value", field.getName());
+
+		Assert.assertEquals(2, field.getTypes().length);
 		Assert.assertEquals("string", field.getTypes()[0]);
+		Assert.assertEquals("null", field.getTypes()[1]);
+
 		Assert.assertEquals(0, generate.getImports().size());
 		Assert.assertEquals("string", field.getTypes()[0]);
 	}
@@ -40,7 +45,11 @@ public class TypeScriptGeneratorTest {
 		Assert.assertEquals(1, generate.getFields().size());
 		FieldModel field = generate.getFields().iterator().next();
 		Assert.assertEquals("model", field.getName());
+
+		Assert.assertEquals(2, field.getTypes().length);
 		Assert.assertEquals("TestModel", field.getTypes()[0]);
+		Assert.assertEquals("null", field.getTypes()[1]);
+
 		Assert.assertEquals(1, generate.getImports().size());
 		Assert.assertEquals("TestModel", generate.getImports().iterator().next().getName());
 	}
@@ -52,8 +61,12 @@ public class TypeScriptGeneratorTest {
 		InterfaceModel generate = TypeScriptGenerator.builder().build().generateModel(descriptor);
 		Assert.assertEquals(1, generate.getFields().size());
 		FieldModel field = generate.getFields().iterator().next();
+		Assert.assertEquals(2, field.getTypes().length);
+
 		Assert.assertEquals("models", field.getName());
 		Assert.assertEquals("TestModel[]", field.getTypes()[0]);
+		Assert.assertEquals("null", field.getTypes()[1]);
+
 		Assert.assertEquals(1, generate.getImports().size());
 		Assert.assertEquals("TestModel", generate.getImports().iterator().next().getName());
 	}
@@ -66,7 +79,11 @@ public class TypeScriptGeneratorTest {
 		Assert.assertEquals(1, generate.getFields().size());
 		FieldModel field = generate.getFields().iterator().next();
 		Assert.assertEquals("models", field.getName());
+
+		Assert.assertEquals(2, field.getTypes().length);
 		Assert.assertEquals("TestModel[]", field.getTypes()[0]);
+		Assert.assertEquals("null", field.getTypes()[1]);
+
 		Assert.assertEquals(1, generate.getImports().size());
 		Assert.assertEquals("TestModel", generate.getImports().iterator().next().getName());
 	}
@@ -79,7 +96,11 @@ public class TypeScriptGeneratorTest {
 		Assert.assertEquals(1, generate.getFields().size());
 		FieldModel field = generate.getFields().iterator().next();
 		Assert.assertEquals("models", field.getName());
+
+		Assert.assertEquals(2, field.getTypes().length);
 		Assert.assertEquals("TestModel[]", field.getTypes()[0]);
+		Assert.assertEquals("null", field.getTypes()[1]);
+
 		Assert.assertEquals(1, generate.getImports().size());
 		Assert.assertEquals("TestModel", generate.getImports().iterator().next().getName());
 	}
@@ -178,6 +199,29 @@ public class TypeScriptGeneratorTest {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.writeValue(writer, sub1);
 		Assert.assertEquals("{\"kind\":\"sub1\",\"value\":null,\"more\":\"hi\"}", writer.toString());
+	}
+
+	@Test
+	public void testTypeIsNotNull() throws IOException {
+		ClassDescriptor descriptor = GeneratorFromClass.createClassDescriptor(TestNotNull.class, new ScanContext(),
+				new PathMapper(TestNotNull.class.getName()));
+		InterfaceModel generate = TypeScriptGenerator.builder().build().generateModel(descriptor);
+		Assert.assertEquals("TestNotNull", generate.getName());
+		Assert.assertEquals(TestNotNull.class.getName(), generate.getFullSlingModelName());
+		Assert.assertEquals(2, generate.getFields().size());
+
+		Iterator<FieldModel> iterator = generate.getFields().iterator();
+		FieldModel field = iterator.next();
+
+		// no null type for booleans
+		Assert.assertEquals("done", field.getName());
+		Assert.assertEquals(1, field.getTypes().length);
+		Assert.assertEquals("boolean", field.getTypes()[0]);
+
+		field = iterator.next();
+		Assert.assertEquals("value", field.getName());
+		Assert.assertEquals(1, field.getTypes().length);
+		Assert.assertEquals("string", field.getTypes()[0]);
 	}
 
 }


### PR DESCRIPTION
Java objects such as "String" can be null. Adds `null` among other types by default. There are cases where we can say that object is 100% not null at the time of serialisation. For those there has been added `@NotNull` annotation. 