### PR TITLE
feat: reuse model used for cache key generation as main request model

### DIFF
--- a/core/src/main/java/com/sinnerschrader/aem/react/cache/ComponentCache.java
+++ b/core/src/main/java/com/sinnerschrader/aem/react/cache/ComponentCache.java
@@ -90,7 +90,8 @@ public class ComponentCache {
 
 	public Object getModel(SlingHttpServletRequest request, String path, String resourceType) {
 		try {
-			return modelFactory.getModelFromRequest(request);
+			Object model =  modelFactory.getModelFromRequest(request);
+			return model;
 		} catch (ModelClassException e) {
 			return null;
 		}
@@ -160,7 +161,7 @@ public class ComponentCache {
 		return caching;
 	}
 
-	public RenderResult cache(CacheKey key, SlingHttpServletRequest request, String path, String resourceType,
+	public RenderResult cache(ModelCollector collector, CacheKey key, SlingHttpServletRequest request, String path, String resourceType,
 			ResultRenderer render) throws Exception {
 		Object cacheableModel = null;
 		if (caching) {
@@ -168,6 +169,7 @@ public class ComponentCache {
 			try {
 				cacheableModel = getModel(request, path, resourceType);
 				if (cacheableModel != null) {
+					collector.addRequestModel(path, cacheableModel);
 					CachedHtml cachedHtml = getHtml(key, cacheableModel);
 					if (cachedHtml != null) {
 

--- a/core/src/main/java/com/sinnerschrader/aem/react/cache/ModelCollector.java
+++ b/core/src/main/java/com/sinnerschrader/aem/react/cache/ModelCollector.java
@@ -1,0 +1,30 @@
+package com.sinnerschrader.aem.react.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModelCollector {
+
+	private Map<String, Object> models;
+
+	public void addRequestModel(String path, Object model) {
+		if (model == null) {
+			return;
+		}
+		if (models == null) {
+			models = new HashMap();
+		}
+		this.models.put(path, model);
+	}
+
+	public Object getModel(String path, String name) {
+		if (models != null) {
+			Object model = models.get(path);
+			if (model != null && model.getClass().getName().equals(name)) {
+				return model;
+			}
+		}
+		return null;
+	}
+
+}

--- a/core/src/test/java/com/sinnerschrader/aem/react/api/ModelFactoryTest.java
+++ b/core/src/test/java/com/sinnerschrader/aem/react/api/ModelFactoryTest.java
@@ -17,6 +17,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sinnerschrader.aem.react.cache.ModelCollector;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ModelFactoryTest {
@@ -60,6 +61,8 @@ public class ModelFactoryTest {
 	@Mock
 	private ObjectMapper mapper;
 	@Mock
+	private ModelCollector modelCollector;
+	@Mock
 	private ResourceResolver resourceResolver;
 
 	@Test
@@ -76,7 +79,7 @@ public class ModelFactoryTest {
 							.getConstructor(new Class[] { SlingHttpServletRequest.class })
 							.newInstance(invoke.getArguments()[0]);
 				});
-		ModelFactory factory = new ModelFactory(getClass().getClassLoader(), context.request(), modelFactory,
+		ModelFactory factory = new ModelFactory(modelCollector,getClass().getClassLoader(), context.request(), modelFactory,
 				adapterManager, new ObjectMapper(), context.resourceResolver());
 
 		JsProxy model = factory.createRequestModel("/test", TestModel.class.getName());
@@ -95,7 +98,7 @@ public class ModelFactoryTest {
 					return ((Class) invoke.getArguments()[1]).getConstructor(new Class[] { Resource.class })
 							.newInstance(invoke.getArguments()[0]);
 				});
-		ModelFactory factory = new ModelFactory(getClass().getClassLoader(), context.request(), modelFactory,
+		ModelFactory factory = new ModelFactory(modelCollector,getClass().getClassLoader(), context.request(), modelFactory,
 				adapterManager, new ObjectMapper(), context.resourceResolver());
 
 		JsProxy model = factory.createResourceModel("/test", TestModel.class.getName());

--- a/core/src/test/java/com/sinnerschrader/aem/react/cache/ComponentCacheTest.java
+++ b/core/src/test/java/com/sinnerschrader/aem/react/cache/ComponentCacheTest.java
@@ -1,0 +1,93 @@
+package com.sinnerschrader.aem.react.cache;
+
+import java.util.Collections;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.factory.ModelFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.sinnerschrader.aem.react.ReactScriptEngine.RenderResult;
+import com.sinnerschrader.aem.react.cache.ComponentCache.ResultRenderer;
+import com.sinnerschrader.aem.react.metrics.ComponentMetricsService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ComponentCacheTest {
+
+	private static final String HTML = "<html>";
+	@Mock
+	private ComponentMetricsService metricsService;
+	@Mock
+	private ModelFactory modelFactory;
+	@Mock
+	private ObjectWriter mapper;
+	@Mock
+	private SlingHttpServletRequest request;
+	@Mock
+	private ResultRenderer renderer;
+
+
+
+	@Before
+	public void before() {
+		Mockito.when(modelFactory.getModelFromRequest(request)).thenReturn(new Object());
+	}
+
+	@Test
+	public void testCacheHit() throws Exception {
+		ComponentCache cache = new ComponentCache(modelFactory, mapper, 5, 5, metricsService, false);
+
+		String path = "/content";
+		String type = "/apps/m100";
+
+		CacheKey key = new CacheKey(path, type, "disabled", true, Collections.EMPTY_LIST);
+		Integer rootNo = 1;
+		RenderResult result = new RenderResult();
+		result.html = HTML;
+		cache.put(key, new Object(), result, rootNo);
+
+		ModelCollector collector = new ModelCollector();
+		RenderResult theResult = cache.cache(collector, key, request, path, type, renderer);
+
+		Assert.assertEquals(theResult.html, HTML);
+		Object model = collector.getModel(path, "java.lang.Object");
+		Assert.assertNotNull(model);
+		Object noModel = collector.getModel(path, "java.lang.ObjectXXX");
+		Assert.assertNull(noModel);
+
+
+	}
+
+
+
+
+	@Test
+	public void testNoHit() throws Exception {
+		ComponentCache cache = new ComponentCache(modelFactory, mapper, 5, 5, metricsService, false);
+
+		String path = "/content";
+		String type = "/apps/m100";
+
+		CacheKey key = new CacheKey(path, type, "disabled", true, Collections.EMPTY_LIST);
+		Integer rootNo = 1;
+		RenderResult result = new RenderResult();
+		result.html = HTML;
+
+		RenderResult newResult = new RenderResult();
+		newResult.html = HTML;
+
+		Mockito.when(renderer.render()).thenReturn(newResult);
+
+		RenderResult theResult = cache.cache(new ModelCollector(), key, request, path, type, renderer);
+
+		Assert.assertEquals(theResult.html, HTML);
+
+	}
+
+}


### PR DESCRIPTION
- collect main model and return it from Cqx.createRequestModel if classname and path match